### PR TITLE
ROS-210: fix flashing of T41

### DIFF
--- a/FXUtil.cpp
+++ b/FXUtil.cpp
@@ -62,6 +62,7 @@ void update_firmware( Stream *in, Stream *out,
 
     if (parse_hex_line( (const char*)line, hex.data, &hex.addr, &hex.num, &hex.code ) == 0) {
       out->printf( "abort - bad hex line %s\n", line );
+      return;
     }
     else if (process_hex_record( &hex ) != 0) { // error on bad hex code
       out->printf( "abort - invalid hex code %d\n", hex.code );
@@ -115,7 +116,9 @@ void update_firmware( Stream *in, Stream *out,
   int user_lines = -1;
   while (user_lines != hex.lines && user_lines != 0) {
     out->printf( "enter %d to flash or 0 to abort\n", hex.lines );
-    read_ascii_line( out, line, sizeof(line) );
+    // Changed the next line to read from "in", the same place image was read.
+    // This allows "out" to be used for debug output if needed.
+    read_ascii_line( in, line, sizeof(line) );
     sscanf( line, "%d", &user_lines );
   }
   

--- a/FlashTxx.h
+++ b/FlashTxx.h
@@ -62,7 +62,8 @@
   #define FLASH_SIZE		(0x800000)		// 8MB
   #define FLASH_SECTOR_SIZE	(0x1000)		// 4KB sector size
   #define FLASH_WRITE_SIZE	(4)			// 4-byte/32-bit writes    
-  #define FLASH_RESERVE		(4*FLASH_SECTOR_SIZE)	// reserve top of flash 
+  //#define FLASH_RESERVE		(4*FLASH_SECTOR_SIZE)	// reserve top of flash
+  #define FLASH_RESERVE		(64*FLASH_SECTOR_SIZE)	// reserve top of flash
   #define FLASH_BASE_ADDR	(0x60000000)		// code starts here
 #elif defined(__IMXRT1062__) && defined(ARDUINO_TEENSY_MICROMOD)
   #define FLASH_ID		"fw_teensyMM"		// target ID (in code)

--- a/FlashTxx.h
+++ b/FlashTxx.h
@@ -62,7 +62,6 @@
   #define FLASH_SIZE		(0x800000)		// 8MB
   #define FLASH_SECTOR_SIZE	(0x1000)		// 4KB sector size
   #define FLASH_WRITE_SIZE	(4)			// 4-byte/32-bit writes    
-  //#define FLASH_RESERVE		(4*FLASH_SECTOR_SIZE)	// reserve top of flash
   #define FLASH_RESERVE		(64*FLASH_SECTOR_SIZE)	// reserve top of flash
   #define FLASH_BASE_ADDR	(0x60000000)		// code starts here
 #elif defined(__IMXRT1062__) && defined(ARDUINO_TEENSY_MICROMOD)


### PR DESCRIPTION
Update FLASH_RESERVE for T41 to account for the sectors used for SEEPROM emulation plus the recovery sector,, which according to this thread (https://forum.pjrc.com/threads/43165-Over-the-Air-firmware-updates-changes-for-flashing-Teensy-3-5-amp-3-6?p=317345&viewfull=1#post317345) is 64 sectors. This seems to match what I was seeing as the WeedbotMCU is storing some data in the emulated EEPROM and I think this is what the flasher was stumbling across.